### PR TITLE
feat: refactor `sample/aggregate` API / streamline resistance mutations page

### DIFF
--- a/api/wiseloculus.py
+++ b/api/wiseloculus.py
@@ -3,16 +3,44 @@
 import logging
 import aiohttp
 import asyncio
+import json # Added for json.dumps
+from typing import Optional, List, Tuple, Any # Added Optional, List, Tuple, Any
+from datetime import datetime # Added datetime for type hinting date_range
 from .lapis import Lapis
 
+
 class WiseLoculusLapis(Lapis):
-    async def fetch_data(self, session, mutation, date_range):
-        payload = {
-            "aminoAcidMutations": [mutation],
+    """Wise-Loculus Instance API"""
+
+    async def fetch_sample_aggregated(
+            self,
+            session: aiohttp.ClientSession, 
+            mutation: str, 
+            mutation_type: str, 
+            date_range: Tuple[datetime, datetime], 
+            location_name: Optional[str] = None
+            ) -> dict[str, Any]:
+        """
+        Fetches aggregated sample data for a given mutation, type, date range, and optional location.
+        """
+        payload: dict[str, Any] = { 
             "sampling_dateFrom": date_range[0].strftime('%Y-%m-%d'),
             "sampling_dateTo": date_range[1].strftime('%Y-%m-%d'),
-            "fields": ["sampling_date"]
+            "fields": ["sampling_date"]  
         }
+
+        if mutation_type == "aminoAcid":
+            payload["aminoAcidMutations"] = [mutation]
+        elif mutation_type == "nucleotide":
+            payload["nucleotideMutations"] = [mutation]
+        else:
+            logging.error(f"Unknown mutation type: {mutation_type}")
+            return {"mutation": mutation, "data": None, "error": "Unknown mutation type"}
+
+        if location_name:
+            payload["location_name"] = location_name  
+
+        logging.debug(f"Fetching sample aggregated with payload: {payload}")
         async with session.post(
             f'{self.server_ip}/sample/aggregated',
             headers={
@@ -25,16 +53,22 @@ class WiseLoculusLapis(Lapis):
                 data = await response.json()
                 return {"mutation": mutation, "data": data.get('data', [])}
             else:
-                logging.error(f"Failed to fetch data for mutation {mutation}.")
+                logging.error(f"Failed to fetch data for mutation {mutation} (type: {mutation_type}, location: {location_name}).")
                 logging.error(f"Status code: {response.status}")
                 logging.error(await response.text())
-                return {"mutation": mutation, "data": None}
+                return {"mutation": mutation, "data": None, "status_code": response.status, "error_details": await response.text()}
 
-    async def fetch_single_mutation(self, mutation, date_range):
+    async def fetch_single_mutation(self, mutation: str, mutation_type: str, date_range: Tuple[datetime, datetime], location_name: Optional[str] = None) -> dict[str, Any]:
+        """
+        Fetches data for a single mutation, specifying its type and optional location.
+        """
         async with aiohttp.ClientSession() as session:
-            return await self.fetch_data(session, mutation, date_range)
+            return await self.fetch_sample_aggregated(session, mutation, mutation_type, date_range, location_name)
 
-    async def fetch_all_data(self, mutations, date_range):
+    async def fetch_all_data(self, mutations: List[str], mutation_type: str, date_range: Tuple[datetime, datetime], location_name: Optional[str] = None) -> List[dict[str, Any]]:
+        """
+        Fetches data for a list of mutations, specifying their type and optional location.
+        """
         async with aiohttp.ClientSession() as session:
-            tasks = [self.fetch_data(session, mutation, date_range) for mutation in mutations]
+            tasks = [self.fetch_sample_aggregated(session, m, mutation_type, date_range, location_name) for m in mutations]
             return await asyncio.gather(*tasks)

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,6 @@ dependencies:
   - numpy
   - pandas=2.2.3
   - pyyaml
-  - seaborn
   - aiohttp
   - requests
   - pytest

--- a/subpages/resistance_mut_silo.py
+++ b/subpages/resistance_mut_silo.py
@@ -19,7 +19,8 @@ wiseLoculus = WiseLoculusLapis(server_ip)
 
 
 def fetch_reformat_data(formatted_mutations, date_range):
-    all_data = asyncio.run(wiseLoculus.fetch_all_data(formatted_mutations, date_range))
+    mutation_type = "aminoAcid"  # as we care about amino acid mutations, as in resistance mutations
+    all_data = asyncio.run(wiseLoculus.fetch_all_data(formatted_mutations,mutation_type, date_range))
 
     # get dates from date_range
     dates = pd.date_range(date_range[0], date_range[1]).strftime('%Y-%m-%d')
@@ -178,8 +179,9 @@ def app():
     st.write("Fetching data for mutations:")
     st.write(mutation1)
     st.write(mutation2)
-    data_mut1 = asyncio.run(wiseLoculus.fetch_single_mutation(mutation1, date_range))
-    data_mut2 = asyncio.run(wiseLoculus.fetch_single_mutation(mutation2, date_range))
+    mutation_type = "aminoAcid"  # as we care about amino acid mutations, as in resistance mutations
+    data_mut1 = asyncio.run(wiseLoculus.fetch_single_mutation(mutation1, mutation_type, date_range))
+    data_mut2 = asyncio.run(wiseLoculus.fetch_single_mutation(mutation2, mutation_type, date_range))
     st.write("Data for mutation 1:")
     st.write(data_mut1)
     st.write("Data for mutation 2:")

--- a/subpages/resistance_mut_silo.py
+++ b/subpages/resistance_mut_silo.py
@@ -129,13 +129,11 @@ def app():
 
     st.write("Select from the following resistance mutation sets:")
 
-    # TODO: currently hardcoded, should be fetched from the server
     options = {
         "3CLpro Inhibitors": 'data/translated_3CLpro_in_ORF1a_mutations.csv',
         "RdRP Inhibitors": 'data/translated_RdRp_in_ORF1a_ORF1b_mutations.csv',
         "Spike mAbs": 'data/translated_Spike_in_S_mutations.csv'
     }
-
 
     selected_option = st.selectbox("Select a resistance mutation set:", options.keys())
 
@@ -144,17 +142,14 @@ def app():
 
     df = pd.read_csv(options[selected_option])
 
-    
     # Get the list of mutations for the selected set
     mutations = df['Mutation'].tolist()
     # Apply the lambda function to each element in the mutations list
     formatted_mutations = mutations
     
-
     # Allow the user to choose a date range
     st.write("Select a date range:")
     date_range = st.date_input("Select a date range:", [pd.to_datetime("2025-02-10"), pd.to_datetime("2025-03-08")])
-
 
     start_date = date_range[0].strftime('%Y-%m-%d')
     end_date = date_range[1].strftime('%Y-%m-%d')
@@ -163,6 +158,24 @@ def app():
     sequence_type_value = "amino acid"
 
     formatted_mutations_str = str(formatted_mutations).replace("'", '"')
+
+
+    ### Python plot ###
+    st.write("### Python Plot")
+    st.write("This plot shows the mutations over time.")
+
+    if st.button("Making Python Plot - manual API calls"):
+        st.write("Fetching data...")
+        df = fetch_reformat_data(formatted_mutations, date_range)
+        
+        # Check if the dataframe is all NaN
+        if df.isnull().all().all():
+            st.error("The fetched data contains only NaN values. Please try a different date range or mutation set.")
+        else:
+            # Plot the heatmap
+            fig = plot_resistance_mutations(df)
+            st.plotly_chart(fig, use_container_width=True)
+    
 
     ### GenSpectrum Dashboard Component ###
 
@@ -206,23 +219,6 @@ def app():
         height=500,
     )
 
-    ### Python plot ###
-    st.write("### Python Plot")
-    st.write("This plot shows the mutations over time.")
-
-    if st.button("Making Python Plot - manual API calls"):
-        st.write("Fetching data...")
-        df = fetch_reformat_data(formatted_mutations, date_range)
-        
-        # Check if the dataframe is all NaN
-        if df.isnull().all().all():
-            st.error("The fetched data contains only NaN values. Please try a different date range or mutation set.")
-        else:
-            # Plot the heatmap
-            fig = plot_resistance_mutations(df)
-            st.plotly_chart(fig, use_container_width=True)
-    
-
     ### Debugging ###
     st.write("### Debugging")
     st.write("This section shows the raw data for the mutations.")
@@ -239,7 +235,6 @@ def app():
     st.write(data_mut1)
     st.write("Data for mutation 2:")
     st.write(data_mut2)
-
 
     st.write('making calls to `sample/aggregated` endpoint for each mutation filtering for `aminoAcidMutations`: ["ORF1b:D475Y"]')
 if __name__ == "__main__":


### PR DESCRIPTION
This PR:
- refactors the current api calls for `aminoAcid`  and `nuclitides`
- reorganizes the `resistanceMutations` page