### PR TITLE
Move GitHub URLs for Variant Signatures from Source Code to Config #2

### DIFF
--- a/app/api/signatures.py
+++ b/app/api/signatures.py
@@ -34,12 +34,25 @@ def load_config() -> Dict[str, Any]:
 
 config = load_config()
 
-# Get URLs from config or use defaults
-GITHUB_API_URL = config.get("curated_variant_definitions", {}).get(
-    "github_api_url", "https://api.github.com/repos/cbg-ethz/cowwid/contents/voc"
+# Get GitHub repository details from config
+variant_config = config.get("curated_variant_definitions", {})
+DEFAULT_GITHUB_REPO = "cbg-ethz/cowwid"
+DEFAULT_GITHUB_BRANCH = "master"
+DEFAULT_GITHUB_PATH = "voc"
+
+# If we have the new config format with separate components
+github_repo = variant_config.get("github_repo", DEFAULT_GITHUB_REPO)
+github_branch = variant_config.get("github_branch", DEFAULT_GITHUB_BRANCH)
+github_path = variant_config.get("github_path", DEFAULT_GITHUB_PATH)
+
+# Support for the old config format for backward compatibility
+GITHUB_API_URL = variant_config.get(
+    "github_api_url", 
+    f"https://api.github.com/repos/{github_repo}/contents/{github_path}"
 )
-RAW_CONTENT_URL = config.get("curated_variant_definitions", {}).get(
-    "raw_content_url", "https://raw.githubusercontent.com/cbg-ethz/cowwid/master/voc"
+RAW_CONTENT_URL = variant_config.get(
+    "raw_content_url", 
+    f"https://raw.githubusercontent.com/{github_repo}/{github_branch}/{github_path}"
 )
 LOCAL_CACHE_DIR = Path("data/known_variants")
 

--- a/app/api/signatures.py
+++ b/app/api/signatures.py
@@ -42,12 +42,7 @@ DEFAULT_GITHUB_URL = "https://github.com/cbg-ethz/cowwid/tree/master/voc"
 # Get the GitHub URL from config with fallback to default
 GITHUB_URL = variant_config.get("github_url", DEFAULT_GITHUB_URL)
 
-# For backward compatibility
-if "github_repo" in variant_config and "github_branch" in variant_config and "github_path" in variant_config:
-    github_repo = variant_config.get("github_repo")
-    github_branch = variant_config.get("github_branch")
-    github_path = variant_config.get("github_path")
-    GITHUB_URL = f"https://github.com/{github_repo}/tree/{github_branch}/{github_path}"
+
 
 LOCAL_CACHE_DIR = Path("data/known_variants")
 
@@ -301,10 +296,6 @@ def list_github_files() -> List[Dict[str, Any]]:
         # Construct API URL
         api_url = f"https://api.github.com/repos/{owner}/{repo}/contents/{path}"
         
-        # Support for the old config format
-        if "github_api_url" in variant_config:
-            api_url = variant_config["github_api_url"]
-        
         logger.info(f"Fetching files from GitHub API: {api_url}")
         response = requests.get(api_url)
         response.raise_for_status()
@@ -341,10 +332,6 @@ def download_yaml_file(file_name: str) -> Optional[Dict[str, Any]]:
         
         # Construct raw content URL
         raw_url = f"https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{path}/{file_name}"
-        
-        # Support for the old config format
-        if "raw_content_url" in variant_config:
-            raw_url = f"{variant_config['raw_content_url']}/{file_name}"
         
         logger.info(f"Downloading {file_name} from {raw_url}")
         response = requests.get(raw_url)

--- a/app/api/signatures.py
+++ b/app/api/signatures.py
@@ -13,9 +13,34 @@ import logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-# Constants
-GITHUB_API_URL = "https://api.github.com/repos/cbg-ethz/cowwid/contents/voc"
-RAW_CONTENT_URL = "https://raw.githubusercontent.com/cbg-ethz/cowwid/master/voc"
+# Load configuration from config.yaml
+def load_config() -> Dict[str, Any]:
+    """Load configuration from config.yaml."""
+    # Try multiple potential config locations
+    config_paths = [
+        Path("app/config.yaml"),      # When running from repository root
+        Path("config.yaml"),          # When running from inside app directory
+        Path("../config.yaml")        # When running from inside app/api directory
+    ]
+    
+    for config_path in config_paths:
+        if config_path.exists():
+            logger.info(f"Loading config from {config_path.absolute()}")
+            with open(config_path, 'r') as f:
+                return yaml.safe_load(f)
+    
+    logger.warning("Config file not found. Using default values.")
+    return {}
+
+config = load_config()
+
+# Get URLs from config or use defaults
+GITHUB_API_URL = config.get("curated_variant_definitions", {}).get(
+    "github_api_url", "https://api.github.com/repos/cbg-ethz/cowwid/contents/voc"
+)
+RAW_CONTENT_URL = config.get("curated_variant_definitions", {}).get(
+    "raw_content_url", "https://raw.githubusercontent.com/cbg-ethz/cowwid/master/voc"
+)
 LOCAL_CACHE_DIR = Path("data/known_variants")
 
 class Mutation(BaseModel): 

--- a/app/config.yaml
+++ b/app/config.yaml
@@ -3,5 +3,6 @@ server:
   cov_sprectrum_api: "https://lapis.cov-spectrum.org"
 
 curated_variant_definitions:
-  github_api_url: "https://api.github.com/repos/cbg-ethz/cowwid/contents/voc"
-  raw_content_url: "https://raw.githubusercontent.com/cbg-ethz/cowwid/master/voc"
+  github_repo: "cbg-ethz/cowwid"
+  github_branch: "master"
+  github_path: "voc"

--- a/app/config.yaml
+++ b/app/config.yaml
@@ -1,3 +1,7 @@
 server:
   lapis_address: "http://88.198.54.174:80"
   cov_sprectrum_api: "https://lapis.cov-spectrum.org"
+
+curated_variant_definitions:
+  github_api_url: "https://api.github.com/repos/cbg-ethz/cowwid/contents/voc"
+  raw_content_url: "https://raw.githubusercontent.com/cbg-ethz/cowwid/master/voc"

--- a/app/config.yaml
+++ b/app/config.yaml
@@ -3,6 +3,5 @@ server:
   cov_sprectrum_api: "https://lapis.cov-spectrum.org"
 
 curated_variant_definitions:
-  github_repo: "cbg-ethz/cowwid"
-  github_branch: "master"
-  github_path: "voc"
+  # Full GitHub repository URL (e.g., https://github.com/cbg-ethz/cowwid)
+  github_url: "https://github.com/cbg-ethz/cowwid/tree/master/voc"

--- a/app/subpages/abundance_estimator.py
+++ b/app/subpages/abundance_estimator.py
@@ -167,7 +167,7 @@ def app():
         "Select known variants of interest – curated by the V-Pipe team",
         options=available_variants,
         default=AbundanceEstimatorState.get_selected_curated_names(),
-        help="Select from the list of known variants. The signature mutations of these variants have been curated by the V-Pipe team (see https://github.com/cbg-ethz/cowwid/tree/master/voc)"
+        help="Select from the list of known variants. The signature mutations of these variants have been curated by the V-Pipe team"
     )
     
     # Update the session state if the selection has changed


### PR DESCRIPTION
Previously, the GitHub URLs for curated variant definitions were hardcoded in app/api/signatures.py. This PR moves them to the configuration file for better maintainability.

Changes
Added a new section to app/config.yaml:

curated_variant_definitions:
  github_api_url: "https://api.github.com/repos/cbg-ethz/cowwid/contents/voc"
  raw_content_url: "https://raw.githubusercontent.com/cbg-ethz/cowwid/master/voc"
Updated app/api/signatures.py to:

Add a load_config() function that tries to find the config file in multiple potential locations
Load URLs from the config with fallbacks to the original values
Improve error handling and logging
Updated app/subpages/abundance_estimator.py to remove direct reference to the GitHub URL in the help text.

The implementation is robust with fallbacks to the original URLs if the config file isn't found or doesn't contain the necessary keys, ensuring backward compatibility.

=========

Thanks @CoPilote