### PR TITLE
fix: sorting mutation variant / abundance estimator fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,8 @@ deployment.log
 # Environment variables with sensitive information
 .env
 
+# VsCode settings
+.vscode/
+
 # Exclude data files that shouldn't be committed
 data/known_variants/*.yaml

--- a/app/process/variants.py
+++ b/app/process/variants.py
@@ -1,0 +1,72 @@
+"""
+Variant processing utilities.
+
+This module contains functions for processing variant data,
+creating mutation-variant matrices, and related utilities.
+"""
+
+import pandas as pd
+from typing import List, Any
+from .mutations import extract_position
+
+
+def create_mutation_variant_matrix(combined_variants: Any) -> pd.DataFrame:
+    """Create a mutation-variant matrix DataFrame.
+
+    This function builds a binary matrix where:
+    - Rows represent unique mutations across all selected variants
+    - Columns represent variant names (sorted alphabetically)
+    - Values are 1 if the mutation is present in the variant's signature, 0 otherwise
+
+    Args:
+        combined_variants: Object containing a list of variant objects with 'name' and 'signature_mutations' attributes
+
+    Returns:
+        pd.DataFrame: Mutation-variant matrix with mutations as rows and variants as columns
+
+    The matrix is sorted by:
+    - Mutations: by genomic position in descending order
+    - Variants: alphabetically by variant name
+    """
+    # Collect all unique mutations across selected variants
+    all_mutations = set()
+    for variant in combined_variants.variants:
+        all_mutations.update(variant.signature_mutations)
+
+    # Sort mutations for consistent display
+    all_mutations = sorted(list(all_mutations))
+
+    # Create a DataFrame with mutations as rows and variants as columns
+    matrix_data = []
+    for mutation in all_mutations:
+        row = [mutation]
+        for variant in combined_variants.variants:
+            # 1 if mutation is in variant's signature mutations, 0 otherwise
+            row.append(1 if mutation in variant.signature_mutations else 0)
+        matrix_data.append(row)
+
+    # Create column names (variant names)
+    columns = ["Mutation"] + [variant.name for variant in combined_variants.variants]
+
+    # Sort mutations by position number using the utility function
+    matrix_data.sort(key=lambda x: extract_position(x[0]), reverse=True)  # Sort by position in descending order
+
+    # Sort columns alphabetically by variant name, but keep "Mutation" as the first column
+    variant_columns = columns[1:]  # Skip the "Mutation" column
+    variant_columns.sort()  # Sort alphabetically
+    columns = ["Mutation"] + variant_columns
+
+    # Create a mapping from original variant order to sorted order
+    original_variant_order = [variant.name for variant in combined_variants.variants]
+    variant_index_map = {name: original_variant_order.index(name) for name in original_variant_order}
+
+    # Reorder each row's data to match the sorted columns
+    for row in matrix_data:
+        original_data = row[1:]  # Data in original variant order
+        sorted_data = [original_data[variant_index_map[name]] for name in variant_columns]
+        row[1:] = sorted_data
+
+    # Create DataFrame
+    matrix_df = pd.DataFrame(matrix_data, columns=columns)
+
+    return matrix_df

--- a/app/subpages/abundance_estimator.py
+++ b/app/subpages/abundance_estimator.py
@@ -37,7 +37,7 @@ from components.variant_signature_component import render_signature_composer
 from state import AbundanceEstimatorState
 from api.signatures import Variant as SignatureVariant
 from api.signatures import VariantList as SignatureVariantList
-from process.mutations import extract_position, sort_mutations_by_position
+from process.variants import create_mutation_variant_matrix
 from utils.config import get_wiseloculus_url, get_covspectrum_url
 from utils.url_state import create_url_state_manager
 
@@ -490,36 +490,8 @@ def app():
     # Build the mutation-variant matrix
     elif combined_variants.variants:
         
-        # Collect all unique mutations across selected variants
-        all_mutations = set()
-        for variant in combined_variants.variants:
-            all_mutations.update(variant.signature_mutations)
-        
-        # Sort mutations for consistent display
-        all_mutations = sorted(list(all_mutations))
-        
-        # Create a DataFrame with mutations as rows and variants as columns
-        matrix_data = []
-        for mutation in all_mutations:
-            row = [mutation]
-            for variant in combined_variants.variants:
-                # 1 if mutation is in variant's signature mutations, 0 otherwise
-                row.append(1 if mutation in variant.signature_mutations else 0)
-            matrix_data.append(row)
-        
-        # Create column names (variant names)
-        columns = ["Mutation"] + [variant.name for variant in combined_variants.variants]
-
-        # Sort mutations by position number using the utility function
-        matrix_data.sort(key=lambda x: extract_position(x[0]), reverse=True)  # Sort by position in descending order
-        
-        # Sort columns alphabetically by variant name, but keep "Mutation" as the first column
-        variant_columns = columns[1:]  # Skip the "Mutation" column
-        variant_columns.sort()  # Sort alphabetically
-        columns = ["Mutation"] + variant_columns
-        
-        # Create DataFrame
-        matrix_df = pd.DataFrame(matrix_data, columns=columns)
+        # Create the mutation-variant matrix using the utility function
+        matrix_df = create_mutation_variant_matrix(combined_variants)
         
         # Create a section with two visualizations side by side
         

--- a/app/subpages/abundance_estimator.py
+++ b/app/subpages/abundance_estimator.py
@@ -511,7 +511,7 @@ def app():
         columns = ["Mutation"] + [variant.name for variant in combined_variants.variants]
 
         # Sort mutations by position number using the utility function
-        matrix_data.sort(key=lambda x: extract_position(x[0]))  # Sort by position in ascending order
+        matrix_data.sort(key=lambda x: extract_position(x[0]), reverse=True)  # Sort by position in descending order
         
         # Sort columns alphabetically by variant name, but keep "Mutation" as the first column
         variant_columns = columns[1:]  # Skip the "Mutation" column

--- a/app/tests/test_variants.py
+++ b/app/tests/test_variants.py
@@ -1,0 +1,96 @@
+
+"""
+Tests for the process.variants module.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import pandas as pd
+from typing import List
+from process.variants import create_mutation_variant_matrix
+
+
+
+
+class MockVariant:
+    """Mock variant class for testing."""
+    def __init__(self, name: str, signature_mutations: List[str]):
+        self.name = name
+        self.signature_mutations = signature_mutations
+
+
+class MockVariantList:
+    """Mock variant list class for testing."""
+    def __init__(self, variants: List[MockVariant]):
+        self.variants = variants
+
+
+class TestCreateMutationVariantMatrix:
+    """Test the create_mutation_variant_matrix function."""
+
+    def test_basic_functionality(self):
+        """Test basic matrix creation with simple data."""
+        # Create mock data
+        combined_variants = MockVariantList([
+            MockVariant("Delta", ["C123T", "A456G"]),
+            MockVariant("Omicron", ["C123T", "G234A"])
+        ])
+
+        result = create_mutation_variant_matrix(combined_variants)
+
+        # Check basic structure
+        assert isinstance(result, pd.DataFrame)
+        assert "Mutation" in result.columns
+        assert "Delta" in result.columns
+        assert "Omicron" in result.columns
+
+        # Check data correctness
+        assert len(result) == 3  # 3 unique mutations
+        assert set(result["Mutation"].tolist()) == {"A456G", "C123T", "G234A"}
+
+    def test_matrix_values_correctness(self):
+        """Test that matrix values are correct (1=present, 0=absent)."""
+        combined_variants = MockVariantList([
+            MockVariant("VariantA", ["C100T", "A200G"]),
+            MockVariant("VariantB", ["C100T", "T300C"])
+        ])
+
+        result = create_mutation_variant_matrix(combined_variants)
+
+        # Check specific values
+        c100t_row = result[result["Mutation"] == "C100T"]
+        assert c100t_row["VariantA"].iloc[0] == 1  # Present in VariantA
+        assert c100t_row["VariantB"].iloc[0] == 1  # Present in VariantB
+
+        a200g_row = result[result["Mutation"] == "A200G"]
+        assert a200g_row["VariantA"].iloc[0] == 1  # Present in VariantA
+        assert a200g_row["VariantB"].iloc[0] == 0  # Absent in VariantB
+
+        t300c_row = result[result["Mutation"] == "T300C"]
+        assert t300c_row["VariantA"].iloc[0] == 0  # Absent in VariantA
+        assert t300c_row["VariantB"].iloc[0] == 1  # Present in VariantB
+
+    def test_data_alignment_bug_fix(self):
+        """Test that data is correctly aligned after column sorting."""
+        # This test specifically checks the bug we fixed
+        combined_variants = MockVariantList([
+            MockVariant("Zeta", ["C123T", "A456G"]),  # Zeta has both mutations
+            MockVariant("Alpha", ["C123T"]),          # Alpha has only C123T
+            MockVariant("Beta", ["A456G"])            # Beta has only A456G
+        ])
+
+        result = create_mutation_variant_matrix(combined_variants)
+
+        # After sorting, columns should be: Mutation, Alpha, Beta, Zeta
+        # Check that data is correctly aligned
+        c123t_row = result[result["Mutation"] == "C123T"]
+        assert c123t_row["Alpha"].iloc[0] == 1  # Alpha has C123T
+        assert c123t_row["Beta"].iloc[0] == 0   # Beta doesn't have C123T
+        assert c123t_row["Zeta"].iloc[0] == 1   # Zeta has C123T
+
+        a456g_row = result[result["Mutation"] == "A456G"]
+        assert a456g_row["Alpha"].iloc[0] == 0  # Alpha doesn't have A456G
+        assert a456g_row["Beta"].iloc[0] == 1   # Beta has A456G
+        assert a456g_row["Zeta"].iloc[0] == 1   # Zeta has A456G


### PR DESCRIPTION
This PR does two things:

1) sorts the genomic position of the mutations in the mutation variant matrix that is displayed
2) uncoveres and fixes a bug in the rearrangement of the variant signature matrix