### PR TITLE
chore: bump version to v0.4.2-beta

### DIFF
--- a/app/version.py
+++ b/app/version.py
@@ -1,7 +1,7 @@
 """Version information for v-pipe-scout."""
 
 # Static version information (fallback)
-VERSION = "0.4.1-beta"
+VERSION = "0.4.2-beta"
 BUILD_DATE = None
 BUILD_COMMIT = None
 BUILD_TAG = None


### PR DESCRIPTION
This pull request updates the static version information for the `v-pipe-scout` application.

* Updated the `VERSION` variable in `app/version.py` from `"0.4.1-beta"` to `"0.4.2-beta"` to reflect a new release.