### PR TITLE
fix: selection of session state

### DIFF
--- a/app/components/variant_signature_component.py
+++ b/app/components/variant_signature_component.py
@@ -149,7 +149,8 @@ def render_signature_composer(
         key=f'{session_prefix}variantQuery',
         help="Variant queries may use pango lineage queries (either called by pangolin or by Nextclade) "
              "and filter by Nextstrain clades e.g.: BA.5* | nextcladePangoLineage:BA.5* | nextstrainClade:22B, "
-             "see https://lapis-docs.readthedocs.io/en/latest/concepts/variant_query.html#variantquery for details."
+             "see https://lapis-docs.readthedocs.io/en/latest/concepts/variant_query.html#variantquery for details.",
+        placeholder="e.g.: BA.5* | nextcladePangoLineage:BA.5* | nextstrainClade:22B,"
     )
 
     if config['show_nucleotides_only']:

--- a/app/state.py
+++ b/app/state.py
@@ -38,15 +38,7 @@ class AbundanceEstimatorState:
             
         # Selected curated variants (for backward compatibility and UI state)
         if 'ui_selected_curated_names' not in st.session_state:
-            from subpages.abundance_estimator import cached_get_variant_names
-            available_curated_names_init = cached_get_variant_names()
-            # Set a default variant if available - LP.8 is preferred but any will do
-            if "LP.8" in available_curated_names_init:
-                default_variants = ["LP.8"]
-            elif available_curated_names_init:
-                default_variants = [available_curated_names_init[0]]  # Select first available
-            else:
-                default_variants = []
+            default_variants = []
             st.session_state.ui_selected_curated_names = default_variants
         
         # Selected custom variants (for UI state)

--- a/app/subpages/abundance_estimator.py
+++ b/app/subpages/abundance_estimator.py
@@ -188,7 +188,8 @@ def app():
         "Select known variants of interest – curated by the V-Pipe team",
         options=available_variants,
         default=default_variants,
-        help="Select from the list of known variants. The signature mutations of these variants have been curated by the V-Pipe team"
+        help="Select from the list of known variants. The signature mutations of these variants have been curated by the V-Pipe team",
+        placeholder="Start typing to search for variants..."
     )
     
     # Save variant selection to URL


### PR DESCRIPTION
This pull request improves how variant selection is handled in the `abundance_estimator.py` app, ensuring that only available variants are used and that the URL state and UI remain consistent when variants change. The main changes focus on filtering the selected variants to match the current list of available variants and keeping the URL state in sync with user selections.

**Variant selection and filtering improvements:**

* Added logic to filter the selected variants from the URL so only variants that are currently available are used in the selection. This prevents the UI from displaying unavailable variants.
* Updated the default selection logic for the variant multi-select box to use either the filtered URL variants or the current session state, ensuring only available variants are shown by default.

**URL state synchronization:**

* When variants are removed, the URL is updated to reflect the current curated variant selection, maintaining consistency between the UI and the URL state.