### PR TITLE
refactor: mutations over time

### DIFF
--- a/app/api/wiseloculus.py
+++ b/app/api/wiseloculus.py
@@ -513,8 +513,8 @@ class WiseLoculusLapis(Lapis):
                         mutation_data = data_matrix[i][j]
                         
                         # Extract count and coverage from the API response
-                        count = mutation_data.get("count", pd.NA)
-                        coverage = mutation_data.get("coverage", pd.NA)
+                        count = mutation_data.get("count", 0)
+                        coverage = mutation_data.get("coverage", 0)
                         
                         # Calculate frequency from count and coverage
                         frequency = count / coverage if coverage > 0 else pd.NA

--- a/app/api/wiseloculus.py
+++ b/app/api/wiseloculus.py
@@ -680,8 +680,8 @@ class WiseLoculusLapis(Lapis):
                         mutation_data = data_matrix[i][j]
                         
                         # Extract count and coverage from the API response
-                        count = mutation_data.get("count", 0)
-                        coverage = mutation_data.get("coverage", 0)
+                        count = mutation_data.get("count", pd.NA)
+                        coverage = mutation_data.get("coverage", pd.NA)
                         
                         # Calculate frequency from count and coverage
                         frequency = count / coverage if coverage > 0 else pd.NA

--- a/app/api/wiseloculus.py
+++ b/app/api/wiseloculus.py
@@ -12,14 +12,13 @@ from .lapis import Lapis
 from .exceptions import APIError
 from interface import MutationType
 
-from process.mutations import get_symbols_for_mutation_type
-
 # Constants for fallback date range
 FALLBACK_START_DATE, FALLBACK_END_DATE = datetime(2025, 1, 1), datetime(2025, 12, 31)
 
 class WiseLoculusLapis(Lapis):
     """Wise-Loculus Instance API"""
 
+    # TODO: phase out
     async def fetch_sample_aggregated(
             self,
             session: aiohttp.ClientSession, 
@@ -71,6 +70,7 @@ class WiseLoculusLapis(Lapis):
             logging.error(f"Connection error fetching data for mutation {mutation}: {e}")
             return {"mutation": mutation, "data": None, "error": str(e)}
 
+    # TODO: phase out
     async def fetch_mutation_counts(
             self, 
             mutations: List[str], 
@@ -88,174 +88,7 @@ class WiseLoculusLapis(Lapis):
         async with aiohttp.ClientSession() as session:
             tasks = [self.fetch_sample_aggregated(session, m, mutation_type, date_range, location_name) for m in mutations]
             return await asyncio.gather(*tasks, return_exceptions=True)  # return_exceptions to avoid failing the entire batch
-        
-    async def _fetch_coverage_for_mutation(
-            self, 
-            session: aiohttp.ClientSession,
-            mutation: str,
-            mutation_type: MutationType,
-            date_range: Tuple[datetime, datetime],
-            location_name: Optional[str]
-        ) -> Tuple[dict[str, int], dict[str, dict]]:
-        """
-        Fetches coverage data for all possible symbols at a mutation position.
-        Returns (coverage_data, stratified_results).
-        """
-        symbols = get_symbols_for_mutation_type(mutation_type)
-        mutation_base = mutation[:-1]  # Everything except the last character
-        
-        # Fetch data for all possible symbols at this position
-        coverage_tasks = [
-            self.fetch_sample_aggregated(session, f"{mutation_base}{symbol}", mutation_type, date_range, location_name)
-            for symbol in symbols
-        ]
-        coverage_results = await asyncio.gather(*coverage_tasks)
-
-        # Parse coverage_results to extract total counts for each symbol
-        coverage_data = {
-            symbol: sum(entry['count'] for entry in item['data']) if item['data'] else 0
-            for symbol, item in zip(symbols, coverage_results)
-        }
-
-        # Stratify results by sampling_date
-        stratified_results = {}
-        for symbol, item in zip(symbols, coverage_results):
-            if item['data']:
-                for entry in item['data']:
-                    date = entry['sampling_date']
-                    count = entry['count']
-                    if date not in stratified_results:
-                        stratified_results[date] = {"counts": {s: 0 for s in symbols}, "coverage": 0}
-                    stratified_results[date]["counts"][symbol] += count
-                    stratified_results[date]["coverage"] += count
-
-        return coverage_data, stratified_results
-
-    def _calculate_mutation_result(
-            self, 
-            mutation: str, 
-            coverage_data: dict[str, int], 
-            stratified_results: dict[str, dict]
-        ) -> dict[str, Any]:
-        """
-        Calculates the final result for a mutation including overall and stratified statistics.
-        """
-        target_symbol = mutation[-1]
-        total_coverage = sum(coverage_data.values())
-        frequency = coverage_data.get(target_symbol, 0) / total_coverage if total_coverage > 0 else 0
-
-        # Calculate frequency for the target symbol on each date
-        for date, data in stratified_results.items():
-            data["frequency"] = data["counts"].get(target_symbol, 0) / data["coverage"] if data["coverage"] > 0 else 0
-
-        # Build stratified data with proper NA handling
-        stratified_data = [
-            {
-                "sampling_date": date,
-                "coverage": data["coverage"],
-                "frequency": data["frequency"] if data["coverage"] > 0 else "NA",
-                "count": data["counts"].get(target_symbol, 0) if data["coverage"] > 0 else "NA"
-            }
-            for date, data in stratified_results.items()
-        ]
-
-        return {
-            "mutation": mutation,
-            "coverage": total_coverage,
-            "frequency": frequency,
-            "counts": coverage_data,
-            "stratified": stratified_data
-        }
-
-    async def fetch_mutation_counts_and_coverage(
-            self, 
-            mutations: List[str], 
-            mutation_type: MutationType, 
-            date_range: Tuple[datetime, datetime], 
-            location_name: Optional[str] = None
-        ) -> List[dict[str, Any]]:
-        """
-        Fetches the mutation counts and coverage for a list of mutations, specifying their type and optional location.
-
-        Note Amino Acid mutations require gene:change name "ORF1a:V3449I" while nucleotide mutations can be in the form "A123T".
-        """
-  
-        try:
-            timeout = aiohttp.ClientTimeout(total=30)  # 30 second timeout
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                combined_results = []
-
-                for mutation in mutations:
-                    # Fetch coverage data for all possible symbols at this position
-                    coverage_data, stratified_results = await self._fetch_coverage_for_mutation(
-                        session, mutation, mutation_type, date_range, location_name
-                    )
-                    
-                    # Calculate and append the result for this mutation
-                    mutation_result = self._calculate_mutation_result(mutation, coverage_data, stratified_results)
-                    combined_results.append(mutation_result)
-
-                return combined_results
-        except Exception as e:
-            logging.error(f"Error fetching mutation counts and coverage: {e}")
-            # Return empty results for all mutations
-            return [{"mutation": mutation, "coverage": 0, "frequency": 0, "counts": {}, "stratified": []} for mutation in mutations]
-        
-    
-    async def fetch_counts_coverage_freq(self, mutations: List[str], mutation_type: MutationType, date_range: Tuple[datetime, datetime], location_name: str) -> pd.DataFrame:
-        """Fetches mutation counts, coverage, and frequency for a list of nucleotide mutations over a date range.
-
-        Args:
-            mutations (list): List of nucleotide mutations to fetch data for.
-            date_range (tuple): Tuple containing start and end dates for the data range.
-
-        Returns:
-            pd.DataFrame: A MultiIndex DataFrame with mutation and sampling_date as the index, and count, coverage, and frequency as columns.
-        """
-
-        try:
-            all_data = await self.fetch_mutation_counts_and_coverage(mutations, mutation_type, date_range, location_name)
-
-            # Debug logging
-            logging.debug(f"fetch_counts_coverage_freq: Received {len(all_data)} mutation results")
-
-            # Flatten the data into a list of records
-            records = []
-            for mutation_data in all_data:
-                mutation = mutation_data["mutation"]
-                stratified_data = mutation_data.get("stratified", [])
-                logging.debug(f"Mutation {mutation}: {len(stratified_data)} stratified entries")
-                
-                for stratified in stratified_data:
-                    records.append({
-                        "mutation": mutation,
-                        "sampling_date": stratified["sampling_date"],
-                        "count": stratified["count"],
-                        "coverage": stratified["coverage"],
-                        "frequency": stratified["frequency"]
-                    })
-
-            logging.debug(f"Created {len(records)} records from API data")
-
-            # Create a DataFrame from the records
-            df = pd.DataFrame(records)
-
-            # Only set MultiIndex if we have data and the required columns exist
-            if not df.empty and "mutation" in df.columns and "sampling_date" in df.columns:
-                df.set_index(["mutation", "sampling_date"], inplace=True)
-            else:
-                # Create empty DataFrame with proper MultiIndex structure
-                df = pd.DataFrame(columns=["count", "coverage", "frequency"])
-                df.index = pd.MultiIndex.from_tuples([], names=["mutation", "sampling_date"])
-
-            # Return the DataFrame
-            return df
-        except Exception as e:
-            logging.error(f"Error fetching mutation counts and coverage: {e}")
-            # Return empty DataFrame with proper MultiIndex structure
-            df = pd.DataFrame(columns=["count", "coverage", "frequency"])
-            df.index = pd.MultiIndex.from_tuples([], names=["mutation", "sampling_date"])
-            return df
+            
 
     async def sample_mutations(
             self, 

--- a/app/subpages/abundance_estimator.py
+++ b/app/subpages/abundance_estimator.py
@@ -821,6 +821,11 @@ def app():
 
             # Add a button to trigger fetching
             if st.button("Fetch Data"):
+                # Validate that location is available
+                if location is None:
+                    st.error("Please ensure a location is selected. Unable to fetch data without a valid location.")
+                    st.stop()
+                
                 # Get the latest mutation list
                 mutations = matrix_df["Mutation"].tolist()
                 
@@ -835,11 +840,13 @@ def app():
                 
                 with st.spinner('Fetching mutation counts and coverage data...'):
                     # Store the result in session state
-                    st.session_state.counts_df3d = asyncio.run(wiseLoculus.fetch_counts_coverage_freq(
+                    # Using the improved mutations_over_time endpoint with daily interval
+                    st.session_state.counts_df3d = asyncio.run(wiseLoculus.mutations_over_time(
                     mutations,
                     MutationType.NUCLEOTIDE,  
                     datetime_range,
-                    location
+                    location,
+                    interval="daily"
                     ))
                 st.success("Data fetched successfully!")
                 

--- a/app/tests/test_wiseloculus.py
+++ b/app/tests/test_wiseloculus.py
@@ -24,66 +24,6 @@ class TestWiseLoculusLapis:
         self.api = WiseLoculusLapis("http://test-server.com")
         self.date_range = (datetime(2024, 1, 1), datetime(2024, 1, 31))
     
-    @pytest.mark.asyncio
-    async def test_fetch_mutation_counts_and_coverage_nucleotide(self):
-        """Test fetch_mutation_counts_and_coverage for nucleotide mutations."""
-        # Mock the fetch_sample_aggregated method to return controlled data
-        mock_responses = {
-            "A123A": {"mutation": "A123A", "data": [{"sampling_date": "2024-01-15", "count": 10}]},
-            "A123T": {"mutation": "A123T", "data": [{"sampling_date": "2024-01-15", "count": 5}]},
-            "A123C": {"mutation": "A123C", "data": [{"sampling_date": "2024-01-15", "count": 3}]},
-            "A123G": {"mutation": "A123G", "data": [{"sampling_date": "2024-01-15", "count": 2}]},
-        }
-        
-        async def mock_fetch_sample_aggregated(session, mutation, mutation_type, date_range, location_name=None):
-            return mock_responses.get(mutation, {"mutation": mutation, "data": []})
-        
-        with patch.object(self.api, 'fetch_sample_aggregated', side_effect=mock_fetch_sample_aggregated):
-            result = await self.api.fetch_mutation_counts_and_coverage(
-                mutations=["A123T"],
-                mutation_type=MutationType.NUCLEOTIDE,
-                date_range=self.date_range
-            )
-        
-        # Assertions
-        assert len(result) == 1
-        mutation_result = result[0]
-        
-        assert mutation_result["mutation"] == "A123T"
-        assert mutation_result["coverage"] == 20  # 10 + 5 + 3 + 2
-        assert mutation_result["frequency"] == 0.25  # 5/20
-        assert mutation_result["counts"] == {"A": 10, "T": 5, "C": 3, "G": 2}
-        
-        # Check stratified data
-        assert len(mutation_result["stratified"]) == 1
-        stratified = mutation_result["stratified"][0]
-        assert stratified["sampling_date"] == "2024-01-15"
-        assert stratified["coverage"] == 20
-        assert stratified["frequency"] == 0.25
-        assert stratified["count"] == 5
-
-    @pytest.mark.asyncio
-    async def test_fetch_mutation_counts_and_coverage_empty_data(self):
-        """Test fetch_mutation_counts_and_coverage with empty data."""
-        async def mock_fetch_sample_aggregated(session, mutation, mutation_type, date_range, location_name=None):
-            return {"mutation": mutation, "data": []}
-        
-        with patch.object(self.api, 'fetch_sample_aggregated', side_effect=mock_fetch_sample_aggregated):
-            result = await self.api.fetch_mutation_counts_and_coverage(
-                mutations=["A123T"],
-                mutation_type=MutationType.NUCLEOTIDE,
-                date_range=self.date_range
-            )
-        
-        # Assertions for empty data
-        assert len(result) == 1
-        mutation_result = result[0]
-        
-        assert mutation_result["mutation"] == "A123T"
-        assert mutation_result["coverage"] == 0
-        assert mutation_result["frequency"] == 0
-        assert mutation_result["counts"] == {"A": 0, "T": 0, "C": 0, "G": 0}
-        assert mutation_result["stratified"] == []
 
     @pytest.mark.asyncio
     async def test_sample_mutations_nucleotide_success(self):
@@ -752,29 +692,3 @@ class TestWiseLoculusLapisLiveAPI:
         except Exception as e:
             pytest.fail(f"Live mutations_over_time amino acid test failed: {e}")
 
-
-if __name__ == "__main__":
-
-    ### testing if the amino acid coverage works with real server data.
-
-    import yaml
-    import pathlib
-    import asyncio
-
-    async def main():
-        CONFIG_PATH = pathlib.Path(__file__).parent.parent / "config.yaml"
-        with open(CONFIG_PATH, 'r') as file:
-            config = yaml.safe_load(file)
-        server_ip = config.get('server', {}).get('lapis_address', 'http://default_ip:8000')
-        wiseLoculus = WiseLoculusLapis(server_ip)
-
-        result = await wiseLoculus.fetch_mutation_counts_and_coverage(
-            mutations=["ORF1a:V3449I"],
-            mutation_type=MutationType.AMINO_ACID,
-            location_name="Zürich (ZH)",
-            date_range=(datetime(2025, 2, 2), datetime(2025, 3, 3))
-        )
-
-        print(result)
-
-    asyncio.run(main())


### PR DESCRIPTION
This PR phases out the mutations-over-time-fallback function that was using the `sample_aggeggate` endpoint and then manually computed the coverage and freqeuncy.