### PR TITLE
feat: filter wildtype/no-data mutations and default to skipping empty…

### DIFF
--- a/app/subpages/region.py
+++ b/app/subpages/region.py
@@ -322,11 +322,11 @@ def app():
     st.write("Shows the mutations over time in wastewater for the selected date range.")
 
     # Add radio button for showing/hiding dates with no data
-    url_show_empty = url_state.load_from_url("show_empty", "Show all dates", str)
+    url_show_empty = url_state.load_from_url("show_empty", "Skip dates with no coverage", str)
     show_empty_dates = st.radio(
         "Date display options:",
         options=["Show all dates", "Skip dates with no coverage"],
-        index=0 if url_show_empty == "Show all dates" else 1
+        index=1 if url_show_empty == "Skip dates with no coverage" else 0
     )
     
     # Save radio button selection to URL


### PR DESCRIPTION
This pull request introduces improvements to mutation filtering and user interface defaults for the mutation plot component and the region subpage. The main changes focus on filtering out irrelevant mutations and updating the default display behavior to skip dates with no coverage.

Mutation filtering enhancements:

* Added logic to filter out wildtype mutations (where reference and alternate alleles are the same) and mutations with no data (maximum count < 1) in `render_mutation_plot_component`, ensuring only meaningful mutations are visualized.

User interface default updates:

* Changed the default selection for the "Date display options" radio button in `render_mutation_plot_component` to "Skip dates with no coverage" instead of "Show all dates", making the visualization cleaner by default.
* Updated the default for the date display radio button in `app/subpages/region.py` to "Skip dates with no coverage", and adjusted the logic for loading and saving the selection from the URL state to reflect this new default.… dates in region explorer