### PR TITLE
Add covvfit fitness inference to variant abundances page

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Specifically, V-Pipe Scout enables:
 - **Composition of variant signatures for abundance estimates**  
     - Leveraging clinical sequence databases (e.g., [CovSpectrum](https://cov-spectrum.org/))  
     - Using curated variant signatures
+- **Variant fitness inference**  
+    - Estimates relative fitness advantages with [covvfit](https://github.com/cbg-ethz/covvfit)  
+    - Pooling data across selected locations, with forecasts of future variant dynamics
 - **URL-based session sharing**  
     - Share analysis configurations via URLs
     - Collaborate by sharing specific page setups
@@ -42,7 +45,8 @@ Further, we will implement:
 - On-demand variant abundance estimates by [Lollipop](https://github.com/cbg-ethz/LolliPop)
 
 V-Pipe Scout brings together:
-- [V-pipe](https://github.com/cbg-ethz/V-pipe) - our prime Wastewater Viral Analysis Pipeline, see [publication](https://www.biorxiv.org/content/10.1101/2023.10.16.562462v1.full). 
+- [V-pipe](https://github.com/cbg-ethz/V-pipe) - our prime Wastewater Viral Analysis Pipeline, see [publication](https://www.biorxiv.org/content/10.1101/2023.10.16.562462v1.full).
+- [covvfit](https://github.com/cbg-ethz/covvfit) - fitness estimates of SARS-CoV-2 variants from variant abundance data, see [publication](https://doi.org/10.1016/j.watres.2026.126018)
 - [GenSpectrum](https://genspectrum.org/) - in particular the novel fast database for genomic sequences [LAPIS-SILO](https://github.com/GenSpectrum/LAPIS-SILO), see [publication](https://bmcbioinformatics.biomedcentral.com/articles/10.1186/s12859-023-05364-3)
 
 


### PR DESCRIPTION
## What
Adds a "Variant fitness inference (covvfit)" section to the Variant Abundances page.
After deconvolution completes, the user can run covvfit to estimate variant fitness
across the selected locations and view the resulting figure, with PDF and CSV downloads.

## How
- Add covvfit to worker/environment.yml (Python downgraded to 3.11, covvfit requires >=3.10,<3.12)
- New worker/covvfit.py: runs no-smoothing deconvolution (bandwidth 0.1) per location,
  pools all locations into one input, then runs `covvfit infer`
- New run_covvfit Celery task wiring it to the UI
- UI section in abundance.py: max-days / horizon sliders, progress polling,
  figure display, plus PDF and pairwise-fitnesses CSV downloads
- Unit test (worker/tests/test_covvfit.py)

## Notes
- covvfit requires un-smoothed deconvolution, so this runs a fresh deconvolution at
  bandwidth 0.1 rather than reusing the smoothed abundance results.
- Minor known cosmetic issue: with a single location the figure legend sits far from
  the panel (covvfit's own layout). Multi-location runs look fine.