### PR TITLE
Add covvfit fitness inference to variant abundances page

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Specifically, V-Pipe Scout enables:
 - **Composition of variant signatures for abundance estimates**  
     - Leveraging clinical sequence databases (e.g., [CovSpectrum](https://cov-spectrum.org/))  
     - Using curated variant signatures
+- **Variant fitness inference**  
+    - Estimates relative fitness advantages with [covvfit](https://github.com/cbg-ethz/covvfit)  
+    - Pooling data across selected locations, with forecasts of future variant dynamics
 - **URL-based session sharing**  
     - Share analysis configurations via URLs
     - Collaborate by sharing specific page setups
@@ -42,7 +45,8 @@ Further, we will implement:
 - On-demand variant abundance estimates by [Lollipop](https://github.com/cbg-ethz/LolliPop)
 
 V-Pipe Scout brings together:
-- [V-pipe](https://github.com/cbg-ethz/V-pipe) - our prime Wastewater Viral Analysis Pipeline, see [publication](https://www.biorxiv.org/content/10.1101/2023.10.16.562462v1.full). 
+- [V-pipe](https://github.com/cbg-ethz/V-pipe) - our prime Wastewater Viral Analysis Pipeline, see [publication](https://www.biorxiv.org/content/10.1101/2023.10.16.562462v1.full).
+- [covvfit](https://github.com/cbg-ethz/covvfit) - fitness estimates of SARS-CoV-2 variants from variant abundance data, see [publication](https://doi.org/10.1016/j.watres.2026.126018)
 - [GenSpectrum](https://genspectrum.org/) - in particular the novel fast database for genomic sequences [LAPIS-SILO](https://github.com/GenSpectrum/LAPIS-SILO), see [publication](https://bmcbioinformatics.biomedcentral.com/articles/10.1186/s12859-023-05364-3)
 
 

--- a/app/subpages/abundance.py
+++ b/app/subpages/abundance.py
@@ -18,6 +18,7 @@ from pydantic import BaseModel
 from typing import List
 import logging
 import os
+import json
 import pickle  
 import base64 
 import asyncio
@@ -1155,8 +1156,113 @@ def app():
                 celery_app,
                 redis_client
             )
-                
-                    
+
+            # ============== COVVFIT FITNESS INFERENCE SECTION ==============
+            # covvfit needs completed deconvolution for all locations.
+            all_locations_done = (
+                    len(st.session_state.location_results) == len(st.session_state.location_tasks)
+                    and len(st.session_state.location_results) > 0
+            )
+
+            if all_locations_done:
+                st.markdown("---")
+                st.subheader("Variant fitness inference (covvfit)")
+
+                # Initialize covvfit session state
+                if 'covvfit_task_id' not in st.session_state:
+                    st.session_state.covvfit_task_id = None
+                if 'covvfit_result' not in st.session_state:
+                    st.session_state.covvfit_result = None
+
+                col_a, col_b = st.columns(2)
+                with col_a:
+                    max_days = st.slider(
+                        "Days of past data to use",
+                        min_value=60, max_value=365, value=180, step=10,
+                        help="How many days of historical data covvfit fits the model to.",
+                    )
+                with col_b:
+                    horizon = st.slider(
+                        "Days to forecast",
+                        min_value=30, max_value=180, value=90, step=10,
+                        help="How many days into the future covvfit projects.",
+                    )
+
+                if st.button("Run fitness inference", type="primary"):
+                    matrix_pickle = base64.b64encode(pickle.dumps(matrix_df)).decode("utf-8")
+
+                    location_data_pickled = {}
+                    for loc, counts_df in st.session_state.location_data.items():
+                        location_data_pickled[loc] = base64.b64encode(
+                            pickle.dumps(counts_df)
+                        ).decode("utf-8")
+
+                    task = celery_app.send_task(
+                        "tasks.run_covvfit",
+                        kwargs={
+                            "location_data": location_data_pickled,
+                            "matrix_df": matrix_pickle,
+                            "max_days": max_days,
+                            "horizon": horizon,
+                        },
+                    )
+
+                    st.session_state.covvfit_task_id = task.id
+                    st.session_state.covvfit_result = None
+                    st.rerun()
+
+                # Poll / display covvfit result
+                if st.session_state.covvfit_task_id is not None:
+                    if st.session_state.covvfit_result is not None:
+                        # We already have the result — display it
+                        # TODO: with a single location covvfit places the legend far
+                        # from the panel, leaving a large gap. Could be tuned via a
+                        # covvfit plot config (right / panel_width / wspace). Left as-is
+                        # for now since multi-location runs (the common case) look fine.
+                        figure_png_b64 = st.session_state.covvfit_result["figure_png"]
+                        st.image(base64.b64decode(figure_png_b64))
+
+                        st.markdown("#### Download fitness data")
+
+                        if "figure_pdf" in st.session_state.covvfit_result:
+                            st.download_button(
+                                label="Download figure (PDF)",
+                                data=base64.b64decode(st.session_state.covvfit_result["figure_pdf"]),
+                                file_name="covvfit_figure.pdf",
+                                mime="application/pdf",
+                            )
+
+                        if "pairwise_fitnesses_csv" in st.session_state.covvfit_result:
+                            st.download_button(
+                                label="Download fitness results (CSV)",
+                                data=st.session_state.covvfit_result["pairwise_fitnesses_csv"],
+                                file_name="covvfit_pairwise_fitnesses.csv",
+                                mime="text/csv",
+                            )
+
+                    else:
+                        # Task is running — check status
+                        covvfit_task = celery_app.AsyncResult(st.session_state.covvfit_task_id)
+                        if covvfit_task.ready():
+                            try:
+                                st.session_state.covvfit_result = covvfit_task.get()
+                                st.rerun()
+                            except Exception as e:
+                                st.error(f"covvfit failed: {str(e)}")
+                        else:
+                            # Show progress from Redis
+                            progress_raw = redis_client.get(
+                                f"task_progress:{st.session_state.covvfit_task_id}"
+                            )
+                            if progress_raw:
+                                progress = json.loads(progress_raw)
+                                st.info(f"⏳ {progress.get('status', 'Running covvfit...')}")
+                            else:
+                                st.info("⏳ Running covvfit...")
+
+                            from streamlit_autorefresh import st_autorefresh
+                            st_autorefresh(interval=5000, key="covvfit_autorefresh")
+
         else:
             # No tasks have been started yet
             if not st.session_state.location_data:

--- a/worker/covvfit.py
+++ b/worker/covvfit.py
@@ -135,6 +135,12 @@ def run_covvfit_inference(
             with open(figure_pdf_path, "rb") as f:
                 result["figure_pdf"] = base64.b64encode(f.read()).decode("utf-8")
 
+        # pairwise fitness table (relative fitness between each pair of variants)
+        pairwise_csv_path = output_dir / "pairwise_fitnesses.csv"
+        if pairwise_csv_path.exists():
+            with open(pairwise_csv_path, "r") as f:
+                result["pairwise_fitnesses_csv"] = f.read()
+
     return result
 
 

--- a/worker/covvfit.py
+++ b/worker/covvfit.py
@@ -1,0 +1,149 @@
+"""This scripts executes deconvolutin with no smoothing and then covvfit infer.
+
+requires the command line tool:
+- covvfit
+"""
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Dict
+import subprocess
+import base64
+import pandas as pd
+import logging
+from deconvolve import devconvolve
+
+# Configure logging for the worker
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+def run_covvfit_inference(
+        location_data: Dict,
+        matrix_df: pd.DataFrame,
+        max_days: int = 180,
+        horizon: int = 90,
+) -> Dict:
+    """
+    Runs no-smoothing deconvolution per location, then covvfit inference on the
+    pooled result, and returns the generated figures.
+
+    Args:
+        location_data: raw mutation counts per city, keyed by location name.
+        matrix_df: the mutation-variant matrix, shared across all locations.
+        max_days: number of past days to restrict the analysis to.
+        horizon: number of future days to forecast.
+
+    Returns:
+        dict with:
+            "figure_png": base64-encoded PNG of the fit figure (for display).
+            "figure_pdf": base64-encoded PDF of the fit figure (for download).
+    """
+    # no smooth deconvolution per location
+    combined_results = {}
+    for location, counts_df in location_data.items():
+        logger.info(f"Running no-smoothing deconvolution for {location}")
+        deconv_result = devconvolve(
+            mutation_counts_df=counts_df,
+            mutation_variant_matrix_df=matrix_df,
+            bandwidth=0.1,
+            bootstraps=0
+        )
+        combined_results[location] = deconv_result["location"]
+
+    # reshape into flat table to prepare for covvfit run
+    rows = []
+    variant_names = set()
+    for location, result_data in combined_results.items():
+        variants = result_data.get(location, result_data)
+
+        for variant, data in variants.items():
+            for point in data.get("timeseriesSummary", []):
+                rows.append({
+                    "location": location,
+                    "variant": variant,
+                    "date": point["date"],
+                    "proportion": point["proportion"],
+                })
+            # "undetermined" stays in the data (covvfit folds it into the
+            # "other" baseline) but is never passed as a -v variant, so we
+            # don't request a fitness estimate for the leftover bucket.
+            if variant != "undetermined":
+                variant_names.add(variant)
+
+    if not rows:
+        raise ValueError("No data found in deconvolution results.")
+
+    variant_names = sorted(variant_names)
+
+    df = pd.DataFrame(rows)
+
+    logger.info(
+        f"Prepared covvfit input with {len(df)} rows across "
+        f"{df['location'].nunique()} locations and {len(variant_names)} variants."
+    )
+
+    with TemporaryDirectory() as tmpdir:
+        tmpdir = Path(tmpdir)
+
+        input_csv = tmpdir / "deconvolved_nosmooth.csv"
+        df.to_csv(input_csv, index=False)
+
+        output_dir = tmpdir / "output"
+
+        covvfit_command = [
+            "covvfit", "infer",
+            "--input", str(input_csv),
+            "--output", str(output_dir),
+            "--separator", ",",
+            "--max-days", str(max_days),
+            "--horizon", str(horizon),
+        ]
+
+        for variant in variant_names:
+            covvfit_command += ["-v", variant]
+
+        logger.info(f"Running command: {' '.join(covvfit_command)}")
+
+        try:
+            subprocess.run(
+                covvfit_command,
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            logger.info("Successfully ran covvfit inference")
+        except subprocess.CalledProcessError as e:
+            logger.error(f"Error running covvfit command: {e}")
+            if e.stderr:
+                logger.error(e.stderr)
+            raise
+        figure_png_path = output_dir / "figure.png"
+        figure_pdf_path = output_dir / "figure.pdf"
+
+        if not figure_png_path.exists():
+            raise FileNotFoundError(
+                f"covvfit did not produce figure.png at {figure_png_path}"
+            )
+
+        with open(figure_png_path, "rb") as f:
+            figure_png_b64 = base64.b64encode(f.read()).decode("utf-8")
+
+        result = {"figure_png": figure_png_b64}
+
+        if figure_pdf_path.exists():
+            with open(figure_pdf_path, "rb") as f:
+                result["figure_pdf"] = base64.b64encode(f.read()).decode("utf-8")
+
+    return result
+
+
+
+
+
+
+
+
+
+
+

--- a/worker/environment.yml
+++ b/worker/environment.yml
@@ -5,7 +5,7 @@ channels:
   - defaults
 dependencies:
   # Python and lollipop dependencies
-  - python=3.13
+  - python=3.11
   - numpy>=1.23
   - scipy>=1.9
   - pandas>=1.5
@@ -35,3 +35,4 @@ dependencies:
   - pip
   - pip:
       - redis==5.0.1
+      - covvfit

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -8,6 +8,7 @@ import pickle
 import base64
 import pandas as pd
 from deconvolve import devconvolve
+from covvfit import run_covvfit_inference
 
 # Initialize Celery
 app = Celery(
@@ -215,3 +216,65 @@ def run_deconvolve(self, mutation_counts_df, mutation_variant_matrix_df,
         progress_data["status"] = f"Error: {error_message}"
         redis_client.set(progress_key, json.dumps(progress_data), ex=3600)
         raise
+
+@app.task(bind=True)
+def run_covvfit(self, location_data, matrix_df, max_days=180, horizon=90):
+    """
+   A task that runs covvfit fitness inference with progress tracking.
+
+   Runs no-smoothing deconvolution per location, pools the results, and runs
+   covvfit inference, returning the generated figures.
+
+   Args:
+       location_data (dict): {location_name: counts_df} — each counts_df is a
+           base64-encoded pickle string of the mutation counts DataFrame.
+       matrix_df (str): base64-encoded pickle string of the mutation-variant matrix.
+       max_days (int): number of past days to restrict the analysis to.
+       horizon (int): number of future days to forecast.
+   """
+
+    task_id = self.request.id
+    progress_key = f"task_progress:{task_id}"
+
+    def update_progress(current, total, message):
+        redis_client.set(
+            progress_key,
+            json.dumps({"current": current, "total": total, "status": message}),
+            ex=3600
+        )
+
+    # deserialize inputs and run
+    try:
+        update_progress(1, 3, "Deserializing inputs")
+
+        # matrix_df arrives as a base64-encoded pickle string (same as run_deconvolve)
+        if isinstance(matrix_df, str):
+            matrix_df = pickle.loads(base64.b64decode(matrix_df))
+
+        # location_data is {location: counts_df}, each counts_df a pickle string
+        deserialized_location_data = {}
+        for location, counts_df in location_data.items():
+            if isinstance(counts_df, str):
+                counts_df = pickle.loads(base64.b64decode(counts_df))
+            deserialized_location_data[location] = counts_df
+
+        update_progress(2, 3, "Running no-smoothing deconvolution and covvfit inference")
+
+        result = run_covvfit_inference(
+            location_data=deserialized_location_data,
+            matrix_df=matrix_df,
+            max_days=max_days,
+            horizon=horizon,
+        )
+
+        update_progress(3, 3, "Completed")
+
+        return result
+
+    except Exception as e:
+        update_progress(0, 3, f"Error: {str(e)}")
+        raise
+
+
+
+

--- a/worker/tests/test_covvfit.py
+++ b/worker/tests/test_covvfit.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+# Add the project root directory to the Python path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+import pandas as pd
+
+from worker.tasks import run_covvfit
+
+
+#-- helpers ---------------------------------------------------------
+
+class FakeRedis:
+    """Capture all .set() calls in-memory."""
+    def __init__(self):
+        self.store = {}
+    def set(self, key, value, ex=None):
+        self.store[key] = value
+
+#-- test ------------------------------------------------------------
+
+def test_run_covvfit_minimal(monkeypatch):
+
+    fake_redis = FakeRedis()
+    monkeypatch.setattr("worker.tasks.redis_client", fake_redis)
+    monkeypatch.setattr(
+        "worker.tasks.run_covvfit_inference",
+        lambda **kwargs: {"figure_png": "fake_base64_png"},
+    )
+
+    # location_data is {location: counts_df}; matrix_df is a DataFrame.
+    # Pass real DataFrames directly — the task's isinstance() guards skip
+    # deserialization when inputs aren't pickled strings.
+    location_data = {"TestCity": pd.DataFrame({"m": [1, 2]})}
+    matrix_df = pd.DataFrame([[0.1, 0.9], [0.5, 0.5]])
+
+    # Bound Celery tasks inject `self` automatically when called directly,
+    # so we do NOT pass it ourselves.
+    result = run_covvfit(location_data, matrix_df)
+
+    assert result == {"figure_png": "fake_base64_png"}


### PR DESCRIPTION
## What
Adds a "Variant fitness inference (covvfit)" section to the Variant Abundances page.
After deconvolution completes, the user can run covvfit to estimate variant fitness
across the selected locations and view the resulting figure, with PDF and CSV downloads.

## How
- Add covvfit to worker/environment.yml (Python pinned to 3.11 — covvfit requires >=3.10,<3.12)
- New worker/covvfit.py: runs no-smoothing deconvolution (bandwidth 0.1) per location,
  pools all locations into one input, then runs `covvfit infer`
- New run_covvfit Celery task wiring it to the UI
- UI section in abundance.py: max-days / horizon sliders, progress polling,
  figure display, plus PDF and pairwise-fitnesses CSV downloads
- Unit test (worker/tests/test_covvfit.py)

## Notes
- covvfit requires un-smoothed deconvolution, so this runs a fresh deconvolution at
  bandwidth 0.1 rather than reusing the smoothed abundance results.
- Minor known cosmetic issue: with a single location the figure legend sits far from
  the panel (covvfit's own layout). Multi-location runs look fine.